### PR TITLE
Fixes the tag when rebuilt catalog by digest only

### DIFF
--- a/v2/internal/pkg/cli/executor.go
+++ b/v2/internal/pkg/cli/executor.go
@@ -835,6 +835,8 @@ func (o *ExecutorSchema) RunMirrorToMirror(cmd *cobra.Command, args []string) er
 		return err
 	}
 
+	tagRebuiltCatalogByDigestOnly(&collectorSchema, o.Opts.LocalStorageFQDN, o.Opts.Global.WorkingDir)
+
 	// call the batch worker
 	// NOTE: we will check for batch errors at the end
 	copiedSchema, batchError := o.Batch.Worker(cmd.Context(), collectorSchema, *o.Opts)
@@ -1229,4 +1231,31 @@ func mandatoryRegistries(opts *mirror.CopyOptions) map[string]struct{} {
 	}
 
 	return regs
+}
+
+func tagRebuiltCatalogByDigestOnly(collectorSchema *v2alpha1.CollectorSchema, localStorageFQDN, workingDir string) {
+	for k, img := range collectorSchema.AllImages {
+		if img.RebuiltTag == "" || !img.Type.IsOperatorCatalog() || strings.Contains(img.Destination, localStorageFQDN) {
+			continue
+		}
+
+		imgSpec, err := image.ParseRef(img.Origin)
+		if err != nil {
+			continue
+		}
+		if !imgSpec.IsImageByDigestOnly() {
+			continue
+		}
+		dest := strings.Split(img.Destination, imgSpec.Algorithm)
+		if len(dest) == 0 {
+			continue
+		}
+
+		filteredImageDigest, err := operator.FilteredCatalogDigest(workingDir, imgSpec.ComponentName(), imgSpec.Digest, img.RebuiltTag)
+		if err != nil {
+			collectorSchema.AllImages[k].Destination = dest[0] + imgSpec.Algorithm + "-" + img.RebuiltTag
+		} else {
+			collectorSchema.AllImages[k].Destination = dest[0] + imgSpec.Algorithm + "-" + string(filteredImageDigest)
+		}
+	}
 }

--- a/v2/internal/pkg/operator/filtered_collector.go
+++ b/v2/internal/pkg/operator/filtered_collector.go
@@ -250,7 +250,7 @@ func (o FilterCollector) collectOperator( //nolint:cyclop // TODO: this needs fu
 	}
 
 	rebuiltTag := ""
-	if result.ToRebuild {
+	if !isFullCatalog(op) {
 		tag, err := digestOfFilter(op)
 		if err != nil {
 			return v2alpha1.CatalogFilterResult{}, err
@@ -258,17 +258,7 @@ func (o FilterCollector) collectOperator( //nolint:cyclop // TODO: this needs fu
 		rebuiltTag = tag
 	}
 
-	// OCPBUGS-52470
-	// check if the original operator was mirrored by digest
 	componentName := imgSpec.ComponentName() + "." + result.Digest
-	if imgSpec.IsImageByDigestOnly() && o.Opts.IsMirrorToDisk() {
-		tag, err := digestOfFilter(op)
-		if err != nil {
-			return v2alpha1.CatalogFilterResult{}, fmt.Errorf("failed to get filter digest for operator mirrored by digest: %w", err)
-		}
-		componentName = imgSpec.ComponentName() + "." + tag
-	}
-
 	relatedImages[componentName] = []v2alpha1.RelatedImage{
 		{
 			Name:          catalogName,
@@ -427,4 +417,13 @@ func (o FilterCollector) ensureCatalogInOCIFormat(ctx context.Context, imgSpec i
 	}
 
 	return nil
+}
+
+func FilteredCatalogDigest(workingDir, catalogName, originalDigest, iscFilterDigest string) (string, error) {
+	imageIndexDir := filepath.Join(workingDir, operatorCatalogsDir, catalogName, originalDigest)
+	filteredCatalogsDir := filepath.Join(imageIndexDir, operatorCatalogFilteredDir)
+
+	filteredImageDigest, err := os.ReadFile(filepath.Join(filteredCatalogsDir, iscFilterDigest, "digest"))
+
+	return string(filteredImageDigest), err
 }


### PR DESCRIPTION
# Description

When an operator catalog is referenced by digest only in the ImageSetConfiguration, the tag on the destination will be the digest of the original one instead of the digest of the rebuilt operator catalog (more details on [OCPBUGS-52470](https://issues.redhat.com/browse/OCPBUGS-52470) 

This PR fixes this scenario for `d2m` and `m2m`. 

# How Has This Been Tested?

With the following ImageSetConfiguration: 

```
kind: ImageSetConfiguration
apiVersion: mirror.openshift.io/v2alpha1
mirror:
  operators:
    - catalog: registry.redhat.io/redhat/redhat-operator-index@sha256:e3368fb4222d7586a1505748f383fa711b2a2baa231dd02c02b974fd19ade942
      packages:
        - name: rhods-operator
          defaultChannel: fast
          channels:
            - name: fast
              minVersion: 2.17.0
              maxVersion: 2.17.0
```

Step 1: Run `m2d` / `d2m` OR `m2m`

Step 2: Check the target registry to see if the tag of the operator catalog is different of `sha256-e3368fb4222d7586a1505748f383fa711b2a2baa231dd02c02b974fd19ade942`

```
Fetching tags for repository: redhat/redhat-operator-index
{
  "name": "redhat/redhat-operator-index",
  "tags": [
    "sha256-b451172d9e23c1965e619009869cbd46fb7a7f57da36954f223e879871271a66"
  ]
}
```

Step 3: save the manifest to a file
skopeo inspect --raw docker://localhost:6000/redhat/redhat-operator-index:sha256-b451172d9e23c1965e619009869cbd46fb7a7f57da36954f223e879871271a66  --tls-verify=false > manifest.json

Step 4: Check if the content of the manifest matches the tag:
```
skopeo manifest-digest manifest.json
sha256:b451172d9e23c1965e619009869cbd46fb7a7f57da36954f223e879871271a66
```

## Expected Outcome
The tag of the operator catalog should be different of the original one specified in the ImageSetConfiguration